### PR TITLE
Added APParallaxViewDelegate protocol with optional methods APParallaxVi...

### DIFF
--- a/APParallaxHeader/UIScrollView+APParallaxHeader.h
+++ b/APParallaxHeader/UIScrollView+APParallaxHeader.h
@@ -27,7 +27,15 @@ enum {
 
 typedef NSUInteger APParallaxTrackingState;
 
+@protocol APParallaxViewDelegate <NSObject>
+@optional
+- (void)APParallaxView:(APParallaxView *)view willChangeFrame:(CGRect)frame;
+- (void)APParallaxView:(APParallaxView *)view didChangeFrame:(CGRect)frame;
+@end
+
 @interface APParallaxView : UIView
+
+@property (weak) id<APParallaxViewDelegate> delegate;
 
 @property (nonatomic, readonly) APParallaxTrackingState state;
 @property (nonatomic, strong) UIImageView *imageView;

--- a/APParallaxHeader/UIScrollView+APParallaxHeader.m
+++ b/APParallaxHeader/UIScrollView+APParallaxHeader.m
@@ -158,7 +158,7 @@ static char UIScrollViewParallaxView;
     //// Cleanup
     CGGradientRelease(gradient3);
     CGColorSpaceRelease(colorSpace);
-
+    
 }
 
 @end
@@ -228,7 +228,13 @@ static char UIScrollViewParallaxView;
     
     if(self.state == APParallaxTrackingActive) {
         CGFloat yOffset = contentOffset.y*-1;
+        if ([self.delegate respondsToSelector:@selector(APParallaxView:willChangeFrame:)]) {
+            [self.delegate APParallaxView:self willChangeFrame:self.frame];
+        }
         [self setFrame:CGRectMake(0, contentOffset.y, CGRectGetWidth(self.frame), yOffset)];
+        if ([self.delegate respondsToSelector:@selector(APParallaxView:didChangeFrame:)]) {
+            [self.delegate APParallaxView:self didChangeFrame:self.frame];
+        }
     }
 }
 


### PR DESCRIPTION
...ew:willChangeFrame: and APParallaxView:didChangeFrame:

Added APParallaxViewDelegate protocol with optional methods APParallaxView:willChangeFrame: and APParallaxView:didChangeFrame:

This removes the need of the user to create a custom observer to handle frame changes. 
e.g If the user uses a UICollectionView as a parallax view, he will most likely also need to invalidate it's layout before the frame changes.
