### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ UIView *customView = [[UIView alloc] init];
 
 APParallaxViewDelegate will notify the delegate about resizing of the parallax view.
 
-####Methods:####
+#### Methods: ####
 
 * ```- (void)parallaxView:(APParallaxView *)view willChangeFrame:(CGRect)frame```
 * ```- (void)parallaxView:(APParallaxView *)view didChangeFrame:(CGRect)frame```


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
